### PR TITLE
Fix Example 1

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -790,15 +790,14 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
             };
             navigator.mediaCapabilities.encodingInfo(configuration)
                 .then((result) => {
-                  console.log(contentType + ' is:'
+                  console.log(result.contentType + ' is:'
                       + (result.supported ? '' : ' NOT') + ' supported,'
                       + (result.smooth ? '' : ' NOT') + ' smooth and'
                       + (result.powerEfficient ? '' : ' NOT') + ' power efficient');
                 })
-                .catch(() => {
-                  console.error(contentType + ' caused encodingInfo to throw');
+                .catch((err) => {
+                  console.error(err, ' caused encodingInfo to throw');
                 });
-            });
           &lt;/script>
         </pre>
       </div>


### PR DESCRIPTION
contentType is not defined within .then() or .catch(), substitute result.contentType and add err argument at catch callback function and console.error(). Remove extra }); following .catch(()=>{});.